### PR TITLE
Fix errors running operators from scripts

### DIFF
--- a/modules/operators/gizmo_object_add.py
+++ b/modules/operators/gizmo_object_add.py
@@ -18,21 +18,27 @@ class OBJECT_OT_ml_gizmo_object_add(Operator):
     bl_options = {'REGISTER', 'INTERNAL', 'UNDO'}
 
     modifier: StringProperty()
+    placement: EnumProperty(default='NONE', items=(
+        ('NONE', 'None', ''),
+        ('CURSOR', '3D Cursor', ''),
+        ('WORLD_ORIGIN', 'World Origin', ''),
+        ('OBJECT', 'Object Origin', ''),
+    ),
+    options={'HIDDEN', 'SKIP_SAVE'})
 
     def execute(self, context):
-        if self.shift:
-            placement = 'CURSOR'
-        elif self.ctrl:
-            placement = 'WORLD_ORIGIN'
-        else:
-            placement = 'OBJECT'
-        
-        assign_gizmo_object_to_modifier(self, context, self.modifier, placement=placement)
+        self.placement = "OBJECT" if self.placement == 'NONE' else self.placement
+        assign_gizmo_object_to_modifier(self, context, self.modifier, placement=self.placement)
 
         return {'FINISHED'}
 
     def invoke(self, context, event):
-        self.shift = event.shift
-        self.ctrl = event.ctrl
+        if self.placement == 'NONE':
+            if event.shift:
+                self.placement = 'CURSOR'
+            elif event.ctrl:
+                self.placement = 'WORLD_ORIGIN'
+            else:
+                self.placement = 'OBJECT'
 
         return self.execute(context)

--- a/modules/operators/modifier_add.py
+++ b/modules/operators/modifier_add.py
@@ -24,6 +24,8 @@ class OBJECT_OT_ml_modifier_add(Operator):
 
     modifier_type: StringProperty(options={'HIDDEN'})
     after_active: BoolProperty(name="After Active", default=False)
+    add_gizmo: BoolProperty(default=False, options={'HIDDEN', 'SKIP_SAVE'})
+    use_world_origin: BoolProperty(default=False, options={'HIDDEN', 'SKIP_SAVE'})
 
     @classmethod
     def poll(cls, context):
@@ -83,9 +85,9 @@ class OBJECT_OT_ml_modifier_add(Operator):
         if ob.modifiers:
             mod = ob.modifiers[-1]
 
-        if self.shift and ob.type in {'CURVE', 'FONT', 'LATTICE', 'MESH', 'SURFACE'}:
+        if self.add_gizmo and ob.type in {'CURVE', 'FONT', 'LATTICE', 'MESH', 'SURFACE'}:
             if mod.type in HAVE_GIZMO_PROPERTY or mod.type == 'UV_PROJECT':
-                placement = 'WORLD_ORIGIN' if self.ctrl else 'OBJECT'
+                placement = 'WORLD_ORIGIN' if self.use_world_origin else 'OBJECT'
                 assign_gizmo_object_to_modifier(self, context, mod.name, placement=placement)
 
         # === Move modifier into place ===
@@ -100,7 +102,7 @@ class OBJECT_OT_ml_modifier_add(Operator):
             return {'FINISHED'}
 
         prefs = bpy.context.preferences.addons[base_package].preferences
-        move = not self.ctrl if prefs.insert_modifier_after_active else self.ctrl 
+        move = not self.use_world_origin if prefs.insert_modifier_after_active else self.use_world_origin
         if self.after_active: # Option to override the preference
             move = True
 
@@ -114,9 +116,9 @@ class OBJECT_OT_ml_modifier_add(Operator):
         return {'FINISHED'}
 
     def invoke(self, context, event):
-        self.ctrl = event.ctrl
-        self.shift = event.shift
-        self.alt = event.alt
+        self.use_world_origin = event.ctrl
+        self.add_gizmo = event.shift
+        self.alt = event.alt # NOTE: never used?
 
         return self.execute(context)
 

--- a/modules/operators/modifier_apply.py
+++ b/modules/operators/modifier_apply.py
@@ -75,6 +75,7 @@ class ApplyModifier:
         items=multi_user_data_apply_method_items,
         default='NONE',
         options={'HIDDEN', 'SKIP_SAVE'})
+    delete_gizmo: BoolProperty(default=False, options={'HIDDEN', 'SKIP_SAVE'})
 
     apply_as: None
     keep_modifier_when_applying_as_shapekey = False
@@ -151,7 +152,7 @@ class ApplyModifier:
             self.report({'INFO'}, "Applied modifier was not first, result may not be as expected")
 
         # Delete the gizmo object and the vertex group
-        if self.shift or prefs.always_delete_gizmo:
+        if self.delete_gizmo or prefs.always_delete_gizmo:
             if not self.keep_modifier_when_applying_as_shapekey:
                 self.delete_gizmo_and_vertex_group(context, ml_active_ob, mod_type, gizmo_ob,
                                                    vert_group)
@@ -159,7 +160,7 @@ class ApplyModifier:
         return {'FINISHED'}
 
     def invoke(self, context, event):
-        self.shift = event.shift
+        self.delete_gizmo = self.delete_gizmo or event.shift
         ml_active_ob = get_ml_active_object()
         active_mod_index = ml_active_ob.ml_modifier_active_index
         active_mod = ml_active_ob.modifiers[active_mod_index]

--- a/modules/operators/modifier_remove.py
+++ b/modules/operators/modifier_remove.py
@@ -23,6 +23,8 @@ class OBJECT_OT_ml_modifier_remove(Operator):
                      "Hold shift to also delete its gizmo object (if it has one)")
     bl_options = {'REGISTER', 'INTERNAL', 'UNDO'}
 
+    delete_gizmo: BoolProperty(default=False, options={'HIDDEN', 'SKIP_SAVE'})
+
     @classmethod
     def poll(cls, ontext):
         ob = get_ml_active_object()
@@ -51,7 +53,7 @@ class OBJECT_OT_ml_modifier_remove(Operator):
         active_mod_index = ml_active_ob.ml_modifier_active_index
         active_mod = ml_active_ob.modifiers[active_mod_index]
 
-        if self.shift or prefs.always_delete_gizmo:
+        if self.delete_gizmo or prefs.always_delete_gizmo:
             self.remove_gizmo_and_vertex_group(context, ml_active_ob, active_mod)
 
         ### Draise - added "with" for Blender 4.0.0 compatibility
@@ -62,7 +64,7 @@ class OBJECT_OT_ml_modifier_remove(Operator):
         return {'FINISHED'}
 
     def invoke(self, context, event):
-        self.shift = event.shift
+        self.delete_gizmo = self.delete_gizmo or event.shift
 
         return self.execute(context)
 


### PR DESCRIPTION
When operators executed from scripts they do not trigger invoke, so self.shift and other attributes are never assigned. It's possible to use `INVOKE_DEFAULT` but then it's limiting operators to non-keyboard modifiers options - therefore I've added new operators options to also support with them without modifiers.

Example report - https://blenderartists.org/t/applying-modifier-causes-error-in-scripts-modules/1577792

@Dangry98