### PR TITLE
fix: Blender 5.0 compatibility for Subdivision Surface modifier

### DIFF
--- a/modules/ui/properties_data_modifier.py
+++ b/modules/ui/properties_data_modifier.py
@@ -1208,68 +1208,75 @@ class DATA_PT_modifiers:
     def SUBSURF(self, layout, ob, md):
         from bpy import context
         layout.row().prop(md, "subdivision_type", expand=True)
-
         split = layout.split()
         col = split.column()
-
         scene = context.scene
-        engine = context.engine
-        show_adaptive_options = (
+        engine = context.engine         
+        if bpy.app.version >= (5, 0, 0):
+            show_adaptive_options = (
             engine == 'CYCLES' and md == ob.modifiers[-1]
-            and scene.cycles.feature_set == 'EXPERIMENTAL' and md.use_limit_surface
-        )
-
-        if show_adaptive_options:
-            col.label(text="Render:")
-            col.prop(ob.cycles, "use_adaptive_subdivision", text="Adaptive")
-            if ob.cycles.use_adaptive_subdivision:
-                col.prop(ob.cycles, "dicing_rate")
-            else:
-                col.prop(md, "render_levels", text="Levels")
-
-            col.separator()
-
-            col.label(text="Viewport:")
-            col.prop(md, "levels", text="Levels")
-
-            col.separator()
+            )
+            use_adaptive = md.use_adaptive_subdivision
         else:
-            col.label(text="Subdivisions:")
-            sub = col.column(align=True)
-            sub.prop(md, "render_levels", text="Render")
-            sub.prop(md, "levels", text="Viewport")
+            show_adaptive_options = (
+            engine == 'CYCLES' and md == ob.modifiers[-1]
+            and scene.cycles.feature_set == 'EXPERIMENTAL'
+            )
+            use_adaptive = ob.cycles.use_adaptive_subdivision            
 
+        col.label(text="Subdivisions:")
+        sub = col.column(align=True)
+        sub.prop(md, "levels", text="Viewport")
+        sub = col.column(align=True)
+        sub.active = (not show_adaptive_options) or (not use_adaptive)
+        sub.prop(md, "render_levels", text="Render")
         sub = col.column()
-        sub.active = (not show_adaptive_options) or (not ob.cycles.use_adaptive_subdivision)
         sub.prop(md, "quality")
-
+        sub.active = (md.use_limit_surface)
+        col.separator()    
+        if show_adaptive_options:
+            if bpy.app.version >= (5, 0, 0):
+                col.prop(md, "use_adaptive_subdivision", text="Adaptive Subdivision")
+            else:
+                col.prop(ob.cycles, "use_adaptive_subdivision", text="Adaptive")
+                if ob.cycles.use_adaptive_subdivision:
+                    col.prop(ob.cycles, "dicing_rate")
+        if show_adaptive_options and use_adaptive:
+            if bpy.app.version >= (5, 0, 0):
+                col.prop(md, "adaptive_space", text="Space")
+                sub = col.column()
+                col.scale_y = 1
+                if md.adaptive_space == 'PIXEL':
+                    col.prop(md, "adaptive_pixel_size", text="Target Pixel Size")
+                    render = max(scene.cycles.dicing_rate * md.adaptive_pixel_size, 0.1)
+                    preview = max(scene.cycles.preview_dicing_rate * md.adaptive_pixel_size, 0.1)
+                    col.label(text=f"Render {render:.2f} px, Viewport {preview:.2f} px")                
+                else:                                               
+                    col.prop(md, "adaptive_object_edge_length", text="Target Edge Length")
+                    render = max(scene.cycles.dicing_rate * md.adaptive_object_edge_length, 0.1)
+                    preview = max(scene.cycles.preview_dicing_rate * md.adaptive_object_edge_length, 0.1)
+                    col.label(text=f"Render {render:.3f} , Viewport {preview:.3f} ")           
+                col.separator()  
+            else:            
+                col.scale_y = 1
+                col.label(text="Final Dicing Rate:")
+                render = max(scene.cycles.dicing_rate * ob.cycles.dicing_rate, 0.1)
+                preview = max(scene.cycles.preview_dicing_rate * ob.cycles.dicing_rate, 0.1)
+                col.label(text=f"Render {render:.2f} px, Preview {preview:.2f} px")    
+     
         col = split.column()
 
         sub = col.column()
-        sub.active = (not show_adaptive_options) or (not ob.cycles.use_adaptive_subdivision)
         sub.label(text="UV Smooth:")
         sub.prop(md, "uv_smooth", text="")
         sub.label(text="Boundary Smooth:")
         sub.prop(md, "boundary_smooth", text="")
-
-        col.prop(md, "show_only_control_edges")
-
+        col.separator()
         sub = col.column()
-        sub.active = (not show_adaptive_options) or (not ob.cycles.use_adaptive_subdivision)
+        sub.prop(md, "show_only_control_edges")
         sub.prop(md, "use_limit_surface")
         sub.prop(md, "use_creases")
         sub.prop(md, "use_custom_normals")
-
-        if show_adaptive_options and ob.cycles.use_adaptive_subdivision:
-            col = layout.column(align=True)
-            col.scale_y = 0.6
-            col.separator()
-            col.label(text="Final Dicing Rate:")
-            col.separator()
-
-            render = max(scene.cycles.dicing_rate * ob.cycles.dicing_rate, 0.1)
-            preview = max(scene.cycles.preview_dicing_rate * ob.cycles.dicing_rate, 0.1)
-            col.label(text=f"Render {render:.2f} px, Preview {preview:.2f} px")
 
     def SURFACE(self, layout, _ob, _md):
         layout.label(text="Settings are inside the Physics tab")


### PR DESCRIPTION
Maintained full backward compatibility with Blender 4.x. But the design's a bit different. Not sure if it fits your philosophy. I tried to make everything compact



<summary>5.0</summary>
<details>
<img width="411" height="284" alt="image" src="https://github.com/user-attachments/assets/42530f5a-4d1b-42fc-860c-7437a60bd9c1" />
</details>
<summary>4.5</summary>
<details>
<img width="408" height="278" alt="image" src="https://github.com/user-attachments/assets/7410e2f1-8aa0-43c5-a0a5-0f6a0dad8a13" />
</details>
<summary>Other layouts I've been thinking about</summary>
<details>
<img width="404" height="343" alt="image" src="https://github.com/user-attachments/assets/3fba76b2-a765-4932-890c-62b2ec7df876" />
<img width="401" height="358" alt="image" src="https://github.com/user-attachments/assets/361f3e57-16f3-4bad-8c20-c1091490c2ec" />
</details>

It might be cool to keep the original idea of replacing the render subdivision settings with adaptive settings, but this requires more thought than I can give it right now